### PR TITLE
Feature:受講生検索と受講生更新における冗長な処理を排除

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ erDiagram
     STUDENTS_COURSES {
         INT course_id PK
         VARCHAR course_name PK
-        INT student_id FK
+        INT student_id FK  "外部キー (STUDENTS.student_id)"
         DATE course_start_at
         DATE course_end_at
     }
@@ -87,23 +87,18 @@ sequenceDiagram
     API -->> User: 200 OK (受講生詳細一覧が返る)
     Note over User, DB: 個別検索フロー
     User ->> API: GET /students/{studentId}
-    alt studentIdの形式が正しくない場合
+    break studentIdの形式が正しくない場合
         API -->> User: 400 BadRequest
-    else studentIdの形式が正しい場合
-        API ->> DB: SELECT 受講生ID一覧
-        DB -->> API: 受講生ID一覧を返す
-        API ->> API: studentIdがテーブルの受講生ID一覧に含まれるか照会
-        alt studentIdがテーブルに存在しない場合
-            API -->> User: 404 NotFound
-        else studentIdがテーブルに存在する場合
-            API ->> DB: SELECT 受講生
-            API ->> DB: SELECT 受講生コース
+    end 
+            API ->> DB: SELECT 受講生<br>WHERE 受講生ID
+            API ->> DB: SELECT 受講生コース<br>WHERE 受講生ID
             DB -->> API: 受講生を返す
             DB -->> API: 受講生コースを返す
             API ->> API: 受講生詳細をビルド
+        break 受講生詳細が空の場合 
+            API -->> User: 404 NotFound:受講生IDが存在しません
+        end 
             API -->> User: 200 OK (受講生詳細詳細が返る)
-        end
-    end
 
 ```
 
@@ -115,13 +110,12 @@ sequenceDiagram
     participant DB as Database
     Note over User, DB: 受講生詳細の新規登録フロー
     User ->> API: POST /students
-    alt 受講生詳細の形式が正しくない場合
+    break 受講生詳細の形式が正しくない場合
         API -->> User: 400 BadRequest
-    else 受講生詳細の形式が正しい場合
+    end
         API ->> DB: INSERT 受講生
         API ->> DB: INSERT 受講生コース
-        API -->> User: 200 OK (テーブルに登録された受講生詳細が帰る)
-    end
+        API -->> User: 200 OK (テーブルに登録された受講生詳細が返る)
 
 ```
 
@@ -132,13 +126,21 @@ sequenceDiagram
     participant DB as Database
     Note over User, DB: 受講生詳細の更新(論理削除)フロー
     User ->> API: PUT /students
-    alt 受講生詳細の形式が正しくない場合
+    break 受講生詳細の形式が正しくない場合
         API -->> User: 400 BadRequest
-    else 受講生詳細の形式が正しい場合
-        API ->> DB: UPDATE 受講生
-        API ->> DB: UPDATE 受講生コース
-        API -->> User: 200 OK (テーブルで更新された受講生詳細が帰る)
     end
+    API ->> DB: SELECT 受講生コースID一覧<br>WHERE 受講生ID
+    DB -->> API:受講生IDに紐づく<br>受講生コースID一覧を返す
+    API ->> API: 更新したい受講生コースが<br>受講生と紐づいたものか判定
+    break 受講生IDに紐づく<br>受講生コースID一覧が空の場合
+        API -->> User: 404 NotFound:受講生IDが存在しません
+    end
+    break 受講生コースIDが受講生IDと紐づかない場合 
+        API -->> User: 404 NotFound:受講生コースIDが受講生IDと紐づきません
+    end
+    API ->> DB: UPDATE 受講生コース<br>WHERE 受講生ID
+    API ->> DB: UPDATE 受講生<br>WHERE 受講生コースID
+    API -->> User: 200 OK (テーブルで更新された受講生詳細が帰る)
 ```
 
 ---
@@ -178,9 +180,8 @@ classDiagram
         +searchstudentDetail(int studentId) StudentDetail
         +registerStudent(StudentDetail studentDetail) StudentDetail
         +updateStudent(StudentDetail studentDetail) StudentDetail
-        -buildStudentDetail(int studentId)
-        -isExistStudentId(int studentId) boolean
-        -sLinkedCourseIdWithStudentId(int studentId, int courseId) boolean
+        -buildStudentDetail(int studentId) StudentDetail
+        -isLinkedCourseIdWithStudentId(StudentCourse course) boolean
     }
     class StudentRepository {
         +searchActiveStudentList()

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ APIです。このAPIは、以下の処理が可能です。
 studentDetail)を組み立てる
 
 ```mermaid
----
-title: StudentDetail (受講生詳細)
----
 erDiagram
     STUDENTS ||--|{ STUDENTS_COURSES: "has"
     STUDENTS {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -67,6 +67,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponseBody'
+        '404':
+          description: 指定された受講生IDが存在しないか、受講生コースIDが受講生IDに紐づかないときのエラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseBody'
 
   /students/{studentId}:
     get:

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -167,6 +167,12 @@ public class StudentController {
               content = @Content(
                   mediaType = "application/json",
                   schema = @Schema(implementation = ErrorResponseBody.class))
+          ),
+          @ApiResponse(
+              responseCode = "404", description = "指定された受講生IDが存在しないか、受講生コースIDが受講生IDに紐づかないときのエラー",
+              content = @Content(
+                  mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponseBody.class))
           )
       }
   )

--- a/src/main/java/raisetech/student/management/exception/InvalidIdException.java
+++ b/src/main/java/raisetech/student/management/exception/InvalidIdException.java
@@ -13,6 +13,11 @@ public class InvalidIdException extends StudentException {
     this.message = "受講生IDが存在しません。";
   }
 
+  public InvalidIdException(int id) {
+    this.field = "argument" + id;
+    this.message = "受講生IDが存在しません。";
+  }
+
   public InvalidIdException(StudentCourse course) {
     this.field = "studentCourse.courseId：" + course.getCourseId();
     this.message = "コースIDが不正です。受講生IDに紐づけられたコースIDを入力してください。";

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -48,10 +48,11 @@ public class StudentService {
    * @return 受講生詳細
    */
   public StudentDetail searchStudentDetail(int studentId) throws InvalidIdException {
-    Student student = new Student();//isExistStudentIdに渡すための仮のStudentを作成
-    student.setStudentId(studentId);
-    isExistStudentId(student);
-    return buildStudentDetail(studentId);
+    StudentDetail studentDetail = buildStudentDetail(studentId);
+    if (studentDetail.getStudent() == null) {
+      throw new InvalidIdException(studentId);
+    }
+    return studentDetail;
   }
 
 
@@ -83,16 +84,22 @@ public class StudentService {
    */
   @Transactional
   public StudentDetail updateStudent(StudentDetail studentDetail) throws InvalidIdException {
+    Student requestStudent = studentDetail.getStudent();
+    List<StudentCourse> requestCourses = studentDetail.getStudentCourseList();
 
-    Student student = studentDetail.getStudent();
-    isExistStudentId(student);
-    repository.updateStudent(student);
-
-    for (StudentCourse course : studentDetail.getStudentCourseList()) {
-      isLinkedCourseIdWithStudentId(course);
-      repository.updateCourse(course);
+    // リクエストボディの受講生コースリストをループで回す
+    for (StudentCourse course : requestCourses) {
+      course.setStudentId(requestStudent.getStudentId());
+      if (isLinkedCourseIdWithStudentId(course)) {//受講生コースのコースIDが受講生IDと紐づくか判定
+        repository.updateCourse(course);//紐づくなら更新処理を行う
+      } else {
+        throw new InvalidIdException(course);//紐づかないなら例外を投げる
+      }
     }
-    return buildStudentDetail(studentDetail.getStudent().getStudentId());
+    //受講生の更新処理を行う
+    repository.updateStudent(requestStudent);
+    StudentDetail responseStudentDetail = buildStudentDetail(requestStudent.getStudentId());
+    return responseStudentDetail;
   }
 
   /**
@@ -124,19 +131,20 @@ public class StudentService {
   }
 
   /**
-   * 引数で渡された受講生コースIDが、データベースにおいて受講生IDと紐づいているかを判定します。
+   * 受講生コーステーブルから、引数で渡された受講生IDと一致する値をもつレコードを検索してコースIDリストを取得し、引数で渡されたコースIDがテーブルにおいて受講生IDと紐づいているかを判定します。
+   * テーブルから取得したコースIDリストが空の場合は、受講生IDが存在しないと判断し、例外を投げます。
    *
    * @param course 受講生コース
    * @return 受講生コースIDが紐づいている場合はtrue
    */
   private boolean isLinkedCourseIdWithStudentId(StudentCourse course) throws InvalidIdException {
     List<Integer> existCourseIdListLinkedStudentId = repository.searchCourseIdListLinkedStudentId(
-        course.getCourseId());
-    if (existCourseIdListLinkedStudentId.contains(course.getCourseId())) {
-      return true;
-    } else {
-      throw new InvalidIdException(course);
+        course.getStudentId());
+    if (existCourseIdListLinkedStudentId.isEmpty()) {
+      //一件もコースIDが返らない場合、受講生IDが存在しないと判断する。
+      throw new InvalidIdException(course.getStudentId());
     }
+    return existCourseIdListLinkedStudentId.contains(course.getCourseId());
   }
 }
 

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -116,21 +116,6 @@ public class StudentService {
   }
 
   /**
-   * 引数で渡された受講生IDが受講生テーブルに存在するかを判定します。
-   *
-   * @param student 受講生
-   * @return 存在する場合はtrue
-   */
-  private boolean isExistStudentId(Student student) throws InvalidIdException {
-    for (int existId : repository.searchStudentIdList()) {
-      if (existId == student.getStudentId()) {
-        return true;
-      }
-    }
-    throw new InvalidIdException(student);
-  }
-
-  /**
    * 受講生コーステーブルから、引数で渡された受講生IDと一致する値をもつレコードを検索してコースIDリストを取得し、引数で渡されたコースIDがテーブルにおいて受講生IDと紐づいているかを判定します。
    * テーブルから取得したコースIDリストが空の場合は、受講生IDが存在しないと判断し、例外を投げます。
    *

--- a/src/test/java/raisetech/student/management/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/student/management/service/StudentServiceTest.java
@@ -1,0 +1,17 @@
+package raisetech.student.management.service;
+
+class StudentServiceTest {
+
+  //@Test
+  //void 受講生一覧検索_アクティブが動作すること() { //テストメソッドに日本語を使うことはよくある
+  //事前準備
+  //StudentService sut = new StudentService();//System Under Test テスト対象システム
+  //List<StudentDetail> expected = sut.searchActiveStudentDetailList();
+
+  //検証
+  //List<StudentDetail> actual = sut.searchActiveStudentDetailList();
+
+  //Assertions.assertEquals(expected, actual);
+  //}
+
+}


### PR DESCRIPTION
# 受講生検索(個別)処理の修正
## 修正前：
受講生検索を行う前に、テーブルに存在する受講生ID一覧を取得し、引数に渡されたstudentIdがテーブルに存在するかを確認する処理を行っていた
```mermaid
sequenceDiagram
    actor User
    participant API as API
    participant DB as Database
    Note over User, DB: 個別検索フロー
    User ->> API: GET /students/{studentId}
    alt studentIdの形式が正しくない場合
        API -->> User: 400 BadRequest
    else studentIdの形式が正しい場合
        API ->> DB: SELECT 受講生ID一覧
        DB -->> API: 受講生ID一覧を返す
        API ->> API: studentIdがテーブルの受講生ID一覧に含まれるか照会
        alt studentIdがテーブルに存在しない場合
            API -->> User: 404 NotFound
        else studentIdがテーブルに存在する場合
            API ->> DB: SELECT 受講生
            API ->> DB: SELECT 受講生コース
            DB -->> API: 受講生を返す
            DB -->> API: 受講生コースを返す
            API ->> API: 受講生詳細をビルド
            API -->> User: 200 OK (受講生詳細詳細が返る)
        end
    end
```

## 修正後：
引数で渡されたstudentIdでまず検索を行い、返ってきた受講生詳細が空の場合に例外を投げるように変更
```mermaid
sequenceDiagram
    actor User
    participant API as API
    participant DB as Database
Note over User, DB: 個別検索フロー
    User ->> API: GET /students/{studentId}
    break studentIdの形式が正しくない場合
        API -->> User: 400 BadRequest
    end 
            API ->> DB: SELECT 受講生<br>WHERE 受講生ID
            API ->> DB: SELECT 受講生コース<br>WHERE 受講生ID
            DB -->> API: 受講生を返す
            DB -->> API: 受講生コースを返す
            API ->> API: 受講生詳細をビルド
        break 受講生詳細が空の場合 
            API -->> User: 404 NotFound:受講生IDが存在しません
        end 
            API -->> User: 200 OK (受講生詳細詳細が返る)
```

# 受講生更新処理の修正
## 修正前：
受講生と受講生コースそれぞれについて、DBにUPDATEを要求する前に、受講生ID一覧と、受講生IDに紐づく受講生コースID一覧を取得して、受講生IDがテーブルに存在するか、また受講生コースIDが受講生IDに紐づくかを都度判定していた
```mermaid
sequenceDiagram
    actor User
    participant API as API
    participant DB as Database
    Note over User, DB: 受講生詳細の更新(論理削除)フロー
    User ->> API: PUT /students
    break 受講生詳細の形式が正しくない場合
        API -->> User: 400 BadRequest
    end
    API ->> DB: SELECT 受講生ID一覧
    DB -->> API: 受講生ID一覧を返す
    API ->> API: studentIdがテーブルの受講生ID一覧に含まれるか照会
break studentIdがテーブルに存在しない場合 
    API -->> User: 404 NotFound
end 
API ->> DB: UPDATE 受講生<br>WHERE 受講生コースID
    API ->> DB: SELECT 受講生コースID一覧<br>WHERE 受講生ID
    DB -->> API:受講生IDに紐づく<br>受講生コースID一覧を返す
    API ->> API: 更新したい受講生コースが<br>受講生と紐づいたものか判定
    break 受講生コースIDが受講生IDと紐づかない場合 
        API -->> User: 404 NotFound:受講生コースIDが受講生IDと紐づきません
    end
    API ->> DB: UPDATE 受講生コース<br>WHERE 受講生ID    
    API -->> User: 200 OK (テーブルで更新された受講生詳細が帰る)
```
## 修正後
まず受講生IDに紐づく受講生コースID一覧を取得する。受講生コースID一覧が空の場合は「受講生IDがテーブルに存在しない」と判断して例外を返す。次に、引数に渡された受講生コースのコースIDが、テーブルから取得した一覧に含まれるかを判定し、含まれない場合は「受講生コースIDが受講生IDに紐づかないと」と判断して例外を返す。例外が発生しなければ受講生コース及び受講生について、DBに対してUPDATEを要求する
```mermaid
sequenceDiagram
    actor User
    participant API as API
    participant DB as Database
    Note over User, DB: 受講生詳細の更新(論理削除)フロー
    User ->> API: PUT /students
    break 受講生詳細の形式が正しくない場合
        API -->> User: 400 BadRequest
    end
    API ->> DB: SELECT 受講生コースID一覧<br>WHERE 受講生ID
    DB -->> API:受講生IDに紐づく<br>受講生コースID一覧を返す
    API ->> API: 更新したい受講生コースが<br>受講生と紐づいたものか判定
    break 受講生IDに紐づく<br>受講生コースID一覧が空の場合
        API -->> User: 404 NotFound:受講生IDが存在しません
    end
    break 受講生コースIDが受講生IDと紐づかない場合 
        API -->> User: 404 NotFound:受講生コースIDが受講生IDと紐づきません
    end
    API ->> DB: UPDATE 受講生コース<br>WHERE 受講生ID
    API ->> DB: UPDATE 受講生<br>WHERE 受講生コースID
    API -->> User: 200 OK (テーブルで更新された受講生詳細が帰る)
```