### PR TITLE
Fix constructor：NoArgsConstructorを許容せず、データクラスのsetterを削除し、データクラスのフィールドをfinalに変更

### DIFF
--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -1,5 +1,7 @@
 package raisetech.student.management.data;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
@@ -66,5 +68,30 @@ public class Student {
 
   @Schema(description = "キャンセルフラグ", example = "false")
   private boolean isDeleted;
+
+  @JsonCreator
+  public Student(@JsonProperty("studentId") int studentId,
+      @JsonProperty("fullname") String fullname,
+      @JsonProperty("kanaName") String kanaName,
+      @JsonProperty("nickname") String nickname,
+      @JsonProperty("email") String email,
+      @JsonProperty("area") String area,
+      @JsonProperty("telephone") String telephone,
+      @JsonProperty("age") int age,
+      @JsonProperty("sex") String sex,
+      @JsonProperty("remark") String remark,
+      @JsonProperty("isDeleted") boolean isDeleted) {
+    this.studentId = studentId;
+    this.fullname = fullname;
+    this.kanaName = kanaName;
+    this.nickname = nickname;
+    this.email = email;
+    this.area = area;
+    this.telephone = telephone;
+    this.age = age;
+    this.sex = sex;
+    this.remark = remark;
+    this.isDeleted = isDeleted;
+  }
 
 }

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -10,64 +10,62 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
-import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 import raisetech.student.management.data.domain.validation.OnUpdate;
 import raisetech.student.management.data.domain.validation.PhoneNumber;
 
 @Schema(description = "受講生")
 @Getter
-@Setter
 public class Student {
 
   @Schema(description = "受講生ID 自動採番を行う", example = "1")
   @Positive(groups = OnUpdate.class)
-  private int studentId;
+  private final int studentId;
 
   @Schema(description = "フルネーム", example = "佐藤花子")
   @NotNull
   @Length(max = 50)
-  private String fullname;
+  private final String fullname;
 
   @Schema(description = "かな", example = "さとうはなこ")
   @NotNull
   @Length(max = 50)
-  private String kanaName;
+  private final String kanaName;
 
   @Schema(description = "ニックネーム", example = "ハナ")
   @Length(max = 50)
-  private String nickname;
+  private final String nickname;
 
   @Schema(description = "Emailアドレス", example = "hanako@raisetech.com")
   @NotNull
   @Email
   @Length(max = 50)
-  private String email;
+  private final String email;
 
   @Schema(description = "居住地（都道府県）", example = "東京都")
   @Length(max = 50)
-  private String area;
+  private final String area;
 
   @Schema(description = "電話番号", example = "070-0000-0000")
   @PhoneNumber
-  private String telephone;
+  private final String telephone;
 
   @Schema(description = "年齢", example = "20")
   @Positive
   @Min(15)
   @Max(80)
-  private int age;
+  private final int age;
 
   @Schema(description = "性別 '男''女''その他'のみが入力可能", example = "女")
   @Pattern(regexp = "^(男|女|その他)$", message = "性別は「男」「女」「その他」のいずれかを入力してください")
-  private String sex;
+  private final String sex;
 
   @Schema(description = "備考", example = "転職活動中")
   @Length(max = 200)
-  private String remark;
+  private final String remark;
 
   @Schema(description = "キャンセルフラグ", example = "false")
-  private boolean isDeleted;
+  private final boolean isDeleted;
 
   @JsonCreator
   public Student(@JsonProperty("studentId") int studentId,

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -1,12 +1,12 @@
 package raisetech.student.management.data;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import raisetech.student.management.data.domain.validation.CourseName;
 import raisetech.student.management.data.domain.validation.OnUpdate;
@@ -14,8 +14,6 @@ import raisetech.student.management.data.domain.validation.OnUpdate;
 @Schema(description = "受講生コース")
 @Getter
 @Setter
-@AllArgsConstructor
-@NoArgsConstructor
 public class StudentCourse {
 
   @Schema(description = "コースID 自動採番を行う", example = "1")
@@ -47,5 +45,18 @@ public class StudentCourse {
     LocalDate now = LocalDate.now();
     this.courseStartAt = now;
     this.courseEndAt = now.plusMonths(6);
+  }
+
+  @JsonCreator
+  public StudentCourse(@JsonProperty("courseId") int courseId,
+      @JsonProperty("courseName") String courseName,
+      @JsonProperty("studentId") int studentId,
+      @JsonProperty("courseStartAt") LocalDate courseStartAt,
+      @JsonProperty("courseEndAt") LocalDate courseEndAt) {
+    this.courseId = courseId;
+    this.courseName = courseName;
+    this.studentId = studentId;
+    this.courseStartAt = courseStartAt;
+    this.courseEndAt = courseEndAt;
   }
 }

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -35,16 +35,48 @@ public class StudentCourse {
   private LocalDate courseStartAt;
 
   @Schema(description = "コース終了予定日 コース開始日の6か月後の日付", example = "2025-07-01")
+  @NotNull(groups = OnUpdate.class)
   private LocalDate courseEndAt;
 
-
+  /**
+   * 受講生詳細登録で呼び出されるコンストラクタです。コース名,受講生IDを受け取り、コンストラクタが呼び出された日付をもとに、受講開始日と受講終了予定日を自動的にセットします。
+   * 受講生詳細更新で呼び出すと、courseIdが0なのでのちの処理でInvalidIdExceptionが投げられます。これにより、受講生詳細更新で子のコンストラクタを呼び出し、意図せず受講終了予定日が書き替えられることを防ぎます。
+   *
+   * @param courseName コース名
+   * @param studentId  受講生ID
+   */
   public StudentCourse(String courseName, int studentId) {
+    this.courseId = 0;
     this.courseName = courseName;
     this.studentId = studentId;
 
     LocalDate now = LocalDate.now();
     this.courseStartAt = now;
     this.courseEndAt = now.plusMonths(6);
+  }
+
+  /**
+   * 受講生詳細更新で呼び出されるコンストラクタです。受講生コースオブジェクトと受講生IDを受け取ります。
+   * 受講生IDが0またはコース名,コース終了予定日がnullのStudentCourseオブジェクトを受け取った場合はNullPointerExceptionを投げます。
+   *
+   * @param requestCourse 受講生コースコースオブジェクト
+   * @param studentId     受講生ID
+   */
+  public StudentCourse(StudentCourse requestCourse, int studentId) {
+    //requestCourseが、受講生詳細更新に必要なコースID,コース名,受講終了予定日を持っていない場合はNullPointerExceptionを投げる
+    if (requestCourse.getCourseId() == 0 |
+        requestCourse.getCourseName().isEmpty() |
+        requestCourse.getCourseEndAt() == null) {
+      throw new NullPointerException();
+
+    } else {
+      this.courseId = requestCourse.getCourseId();
+      this.courseName = requestCourse.getCourseName();
+      this.studentId = studentId;
+      this.courseStartAt = requestCourse.courseStartAt;
+      this.courseEndAt = requestCourse.getCourseEndAt();
+    }
+
   }
 
   @JsonCreator

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -7,18 +7,16 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import lombok.Getter;
-import lombok.Setter;
 import raisetech.student.management.data.domain.validation.CourseName;
 import raisetech.student.management.data.domain.validation.OnUpdate;
 
 @Schema(description = "受講生コース")
 @Getter
-@Setter
 public class StudentCourse {
 
   @Schema(description = "コースID 自動採番を行う", example = "1")
   @Positive(groups = OnUpdate.class)
-  private int courseId;
+  private final int courseId;
 
   @Schema(
       description = "コース名 'Javaコース','AWSコース','デザインコース','Webマーケティングコース','フロントエンドコース'のみが入力可能",
@@ -26,17 +24,17 @@ public class StudentCourse {
   )
   @NotNull
   @CourseName
-  private String courseName;
+  private final String courseName;
 
   @Schema(description = "受講生ID", example = "1")
-  private int studentId;
+  private final int studentId;
 
   @Schema(description = "コース開始日 登録処理が実行された日付", example = "2025-01-01")
-  private LocalDate courseStartAt;
+  private final LocalDate courseStartAt;
 
   @Schema(description = "コース終了予定日 コース開始日の6か月後の日付", example = "2025-07-01")
   @NotNull(groups = OnUpdate.class)
-  private LocalDate courseEndAt;
+  private final LocalDate courseEndAt;
 
   /**
    * 受講生詳細登録で呼び出されるコンストラクタです。コース名,受講生IDを受け取り、コンストラクタが呼び出された日付をもとに、受講開始日と受講終了予定日を自動的にセットします。
@@ -63,7 +61,6 @@ public class StudentCourse {
    * @param studentId     受講生ID
    */
   public StudentCourse(StudentCourse requestCourse, int studentId) {
-    //requestCourseが、受講生詳細更新に必要なコースID,コース名,受講終了予定日を持っていない場合はNullPointerExceptionを投げる
     if (requestCourse.getCourseId() == 0 |
         requestCourse.getCourseName().isEmpty() |
         requestCourse.getCourseEndAt() == null) {

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -18,7 +18,7 @@ import raisetech.student.management.data.domain.validation.OnUpdate;
 @NoArgsConstructor
 public class StudentCourse {
 
-  @Schema(description = "コースID 自動裁判を行う", example = "1")
+  @Schema(description = "コースID 自動採番を行う", example = "1")
   @Positive(groups = OnUpdate.class)
   private int courseId;
 

--- a/src/main/java/raisetech/student/management/data/domain/StudentDetail.java
+++ b/src/main/java/raisetech/student/management/data/domain/StudentDetail.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
@@ -16,7 +15,6 @@ import raisetech.student.management.data.StudentCourse;
 @Getter
 @Setter
 @AllArgsConstructor
-@NoArgsConstructor
 public class StudentDetail {
 
   @NotNull
@@ -27,8 +25,4 @@ public class StudentDetail {
   @Valid
   private List<StudentCourse> studentCourseList;
 
-  public StudentDetail(Student student) {
-    this.student = student;
-    this.studentCourseList.add(new StudentCourse("未登録", student.getStudentId()));
-  }
 }

--- a/src/main/java/raisetech/student/management/data/domain/StudentDetail.java
+++ b/src/main/java/raisetech/student/management/data/domain/StudentDetail.java
@@ -7,22 +7,20 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
 
 @Schema(description = "受講生詳細")
 @Getter
-@Setter
 @AllArgsConstructor
 public class StudentDetail {
 
   @NotNull
   @Valid
-  private Student student;
+  private final Student student;
 
   @NotEmpty
   @Valid
-  private List<StudentCourse> studentCourseList;
+  private final List<StudentCourse> studentCourseList;
 
 }

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -56,7 +56,7 @@ public interface StudentRepository {
   void registerStudent(Student student);
 
   /**
-   * 受講生コースを新規登録します。コースIDに関しては自動裁判を行う。
+   * 受講生コースを新規登録します。コースIDに関しては自動採番を行う。
    *
    * @param course 新規受講生コース
    */

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -89,11 +89,11 @@ public class StudentService {
 
     // リクエストボディの受講生コースリストをループで回す
     for (StudentCourse course : requestCourses) {
-      course.setStudentId(requestStudent.getStudentId());
-      if (isLinkedCourseIdWithStudentId(course)) {//受講生コースのコースIDが受講生IDと紐づくか判定
-        repository.updateCourse(course);//紐づくなら更新処理を行う
+      StudentCourse complementedCourse = new StudentCourse(course, requestStudent.getStudentId());
+      if (isLinkedCourseIdWithStudentId(complementedCourse)) {//受講生コースのコースIDが受講生IDと紐づくか判定
+        repository.updateCourse(complementedCourse);//紐づくなら更新処理を行う
       } else {
-        throw new InvalidIdException(course);//紐づかないなら例外を投げる
+        throw new InvalidIdException(complementedCourse);//紐づかないなら例外を投げる
       }
     }
     //受講生の更新処理を行う


### PR DESCRIPTION
# データクラスのリファクタリング

### ① 設計上のコードの安全性を高めるため、StudentDetail, Student, StudentCourseクラスそれぞれにおいて、引数なしのコンストラクタを許容しないように変更。
→未初期化オブジェクトの生成を防ぐ

### ② ①に伴い、クライアントから受け取るJSONデータがオブジェクトに変換できないエラーを避けるため、StudentクラスとStudentControllerクラスにおいて@JsonCreater,@JsonPropertyを付したコンストラクタを実装

### ③ データクラスからSetterメソッドを削除し、必ずコンストラクタを経由して初期化するよう変更
→StudentCourseを処理内容に応じて初期化するためのコンストラクタを実装
https://github.com/saway261/StudentManagement/pull/6/commits/7b1454385a7f4fac7fcff76965e5e87de7b87ae5
